### PR TITLE
Add `bc` to the nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,5 +6,6 @@
       pkgs.xxd
       pkgs.powertop
       pkgs.gawk
+      pkgs.bc
     ];
   }


### PR DESCRIPTION
The script makes use of the bc command for calculations. Add it to the list of dependencies for the nix shell.