### PR TITLE
Check all PCIe bridge Link Power Management state

### DIFF
--- a/s0ix-selftest-tool.sh
+++ b/s0ix-selftest-tool.sh
@@ -800,7 +800,7 @@ debug_pcie_link_aspm() {
 
 #Function to check PCIe bridge Link Power Management state
 debug_pcie_bridge_lpm() {
-  PCI_SYSFS="/sys/devices/pci0000:00"
+  PCI_SYSFS="/sys/bus/pci/devices"
   PCI_BRIDGE_CLASS="0x060400"
   devices=$(ls ${PCI_SYSFS})
   bridge_devices=()


### PR DESCRIPTION
This tool only checks the PCIe bridge Link Power Management state whose domain and bus is 0000:00. However, the bridges on some other domain and bus will be missed, such as the PCIe bridge 10000:e0:06.0 created by VMD driver.

This patch changes the PCI_SYSFS to "/sys/bus/pci/devices", which lists all PCI devices flatly.

Link: https://bugzilla.kernel.org/show_bug.cgi?id=218394#c8