### PR TITLE
Using a dynamic column

### DIFF
--- a/s0ix-selftest-tool.sh
+++ b/s0ix-selftest-tool.sh
@@ -494,60 +494,49 @@ pkg_output() {
     exit 0
   fi
 
+  # It only shows "CPU%c1 CPU%c6 CPU%c7 Pkg%pc3 Pkg%pc6 Pkg%pc10 SYS%LPI" columns on some machines
+  # while not like "CPU%c1 CPU%c6 CPU%c7 Pkg%pc2 Pkg%pc3 Pkg%pc8 Pkg%pc9 Pk%pc10 SYS%LPI"
+  # so we need to dynamically shift to the correct column
+  # define a variable to store the column number which begins with c7 at index 3
+  # and convert the variable to a number
+  col_num=3
   cc7=$(echo "$turbostat_after_s2idle" | sed -n '/CPU\%c7/{n;p}' |
-    awk '{print $3}')
-  log_output "\nCPU Core C7 residency after S2idle is: $cc7"
+    awk '{print $'"$col_num"'}')
+  if [ -z "$cc7" ]; then
+    log_output "No CPU Core C7 residency"
+    exit 0
+  else
+    log_output "CPU Core C7 residency after S2idle is: $cc7"
+    col_num=$((col_num + 1))
+  fi
 
   rc6=$(echo "$turbostat_after_s2idle" | sed -n '/GFX\%rc6/{n;p}' |
-    awk '{print $4}')
-  log_output "GFX RC6 residency after S2idle is: $rc6"
-  if [ -z "$rc6" ]; then
-    pkg2=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc2/{n;p}' |
-      awk '{print $4}')
-    log_output "CPU Package C-state 2 residency after S2idle is: $pkg2"
+    awk '{print $'"$col_num"'}')
+  if [ ! -z "$rc6" ]; then
+    log_output "GFX RC6 residency after S2idle is: $rc6"
+    col_num=$((col_num + 1))
+  fi
 
-    pkg3=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc3/{n;p}' |
-      awk '{print $5}')
-    log_output "CPU Package C-state 3 residency after S2idle is: $pkg3"
+  for i in 2 3 6 7 8 9; do
+    pkg=$(echo "$turbostat_after_s2idle" | sed -n "/Pkg\%pc$i/{n;p}" |
+      awk '{print $'"$col_num"'}')
+    if [ ! -z "$pkg" ]; then
+      log_output "CPU Package C-state $i residency after S2idle is: $pkg"
+      eval "pkg$i=$pkg"
+      col_num=$((col_num + 1))
+    fi
+  done
 
-    pkg8=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc8/{n;p}' |
-      awk '{print $8}')
-    log_output "CPU Package C-state 8 residency after S2idle is: $pkg8"
-
-    pkg9=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc9/{n;p}' |
-      awk '{print $9}')
-    log_output "CPU Package C-state 9 residency after S2idle is: $pkg9"
-
-    pkg10=$(echo "$turbostat_after_s2idle" | sed -n '/Pk\%pc10/{n;p}' |
-      awk '{print $10}')
+  pkg10=$(echo "$turbostat_after_s2idle" | sed -n '/Pk\%pc10/{n;p}' |
+    awk '{print $'"$col_num"'}')
+  if [ ! -z "$pkg10" ]; then
     log_output "CPU Package C-state 10 residency after S2idle is: $pkg10"
+    col_num=$((col_num + 1))
+  fi
 
-    slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '/SYS\%LPI/{n;p}' |
-      awk '{print $11}')
-    log_output "S0ix residency after S2idle is: $slp_s0"
-  else
-    pkg2=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc2/{n;p}' |
-      awk '{print $5}')
-    log_output "CPU Package C-state 2 residency after S2idle is: $pkg2"
-
-    pkg3=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc3/{n;p}' |
-      awk '{print $6}')
-    log_output "CPU Package C-state 3 residency after S2idle is: $pkg3"
-
-    pkg8=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc8/{n;p}' |
-      awk '{print $9}')
-    log_output "CPU Package C-state 8 residency after S2idle is: $pkg8"
-
-    pkg9=$(echo "$turbostat_after_s2idle" | sed -n '/Pkg\%pc9/{n;p}' |
-      awk '{print $10}')
-    log_output "CPU Package C-state 9 residency after S2idle is: $pkg9"
-
-    pkg10=$(echo "$turbostat_after_s2idle" | sed -n '/Pk\%pc10/{n;p}' |
-      awk '{print $11}')
-    log_output "CPU Package C-state 10 residency after S2idle is: $pkg10"
-
-    slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '/SYS\%LPI/{n;p}' |
-      awk '{print $12}')
+  slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '/SYS\%LPI/{n;p}' |
+    awk '{print $'"$col_num"'}')
+  if [ ! -z "$slp_s0" ]; then
     log_output "S0ix residency after S2idle is: $slp_s0"
   fi
 


### PR DESCRIPTION
On my laptop, it only show pc3, pc6 and pc10, it could not be parsed correctly.

```
Turbostat output:
9.595455 sec
CPU%c1  CPU%c6  CPU%c7  Pkg%pc2 Pkg%pc3 Pkg%pc6 Pk%pc10 SYS%LPI
11.84   38.55   47.68   0.21    0.00    0.06    74.26   0.00
1.59    2.12    93.43   0.21    0.00    0.06    74.26   0.00
1.20    2.23    93.30
0.73    0.81    96.69
0.44    0.51    98.04
23.30   75.75   0.00
21.56   75.78   0.00
23.20   75.80   0.00
22.71   75.40   0.00

CPU Core C7 residency after S2idle is: 47.68
GFX RC6 residency after S2idle is:
CPU Package C-state 2 residency after S2idle is: 0.21
CPU Package C-state 3 residency after S2idle is: 0.00
CPU Package C-state 8 residency after S2idle is:
CPU Package C-state 9 residency after S2idle is:
CPU Package C-state 10 residency after S2idle is:CPU%c1	CPU%c6	CPU%c7	Pkg%pc2	Pkg%pc3	Pkg%pc6	Pk%pc10	SYS%LPI
8.23	42.08	48.41	0.15	0.00	0.01	82.41	0.00
0.37	0.44	97.47	0.15	0.00	0.01	82.42	0.00
1.85	0.94	95.29
1.03	1.64	96.02
0.28	0.51	98.48
15.98	83.27	0.00
14.86	83.29	0.00
15.83	83.40	0.00
15.67	83.16	0.00
S0ix residency after S2idle is:
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: syntax error
```