### PR TITLE
Using a dynamic column

### DIFF
--- a/s0ix-selftest-tool.sh
+++ b/s0ix-selftest-tool.sh
@@ -919,14 +919,15 @@ debug_no_pc8() {
     exit 0
   fi
 
+  TURBO_RESULT_COLUMNS=$(echo "$turbostat_after_s2idle" | sed -n '2p' | sed 's/\t/,/g')
   cc7=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "CPU%c7") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "CPU%c7") '{print $idx}')
   pkg8=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "Pkg%pc8") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "Pkg%pc8") '{print $idx}')
   pkg10=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "Pk%pc10") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "Pk%pc10") '{print $idx}')
   slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "SYS%LPI") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "SYS%LPI") '{print $idx}')
 
   #Check whether PC8,PC10 and S0ix is available after running powertop
   if [[ "$(echo "scale=2; $slp_s0 > 0.00" | bc)" -eq 1 ]]; then
@@ -1063,10 +1064,11 @@ debug_ltr_value() {
     exit 0
   fi
 
+  TURBO_RESULT_COLUMNS=$(echo "$turbostat_after_s2idle" | sed -n '2p' | sed 's/\t/,/g')
   pkg10=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "Pk%pc10") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "Pk%pc10") '{print $idx}')
   slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-    awk -v idx=$(get_column_index "$TURBO_COLUMNS" "SYS%LPI") '{print $idx}')
+    awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "SYS%LPI") '{print $idx}')
 
   #Check whether IP LTR value ignore is helpful to the PC10 and S0ix state
   ltr_ip_num=$(wc -l $PMC_CORE_SYSFS_PATH/ltr_show 2>&1 | awk '{print$1}')
@@ -1084,10 +1086,11 @@ debug_ltr_value() {
 
     if turbostat_after_s2idle=$("$DIR"/turbostat --quiet --show "$TURBO_COLUMNS" \
       echo freeze 2>&1 >/sys/power/state); then
+      TURBO_RESULT_COLUMNS=$(echo "$turbostat_after_s2idle" | sed -n '2p' | sed 's/\t/,/g')
       pkg10=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-        awk -v idx=$(get_column_index "$TURBO_COLUMNS" "Pk%pc10") '{print $idx}')
+        awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "Pk%pc10") '{print $idx}')
       slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-        awk -v idx=$(get_column_index "$TURBO_COLUMNS" "SYS%LPI") '{print $idx}')
+        awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "SYS%LPI") '{print $idx}')
       log_output "PC10 residency is:$pc10"
       log_output "S0ix residency is:$slp_s0"
     else
@@ -1241,8 +1244,9 @@ debug_acpi_dsm() {
 
   if turbostat_after_s2idle=$("$DIR"/turbostat --quiet --show "$TURBO_COLUMNS" \
     echo freeze 2>&1 >/sys/power/state); then
+    TURBO_RESULT_COLUMNS=$(echo "$turbostat_after_s2idle" | sed -n '2p' | sed 's/\t/,/g')
     slp_s0=$(echo "$turbostat_after_s2idle" | sed -n '3p' |
-      awk -v idx=$(get_column_index "$TURBO_COLUMNS" "SYS%LPI") '{print $idx}')
+      awk -v idx=$(get_column_index "$TURBO_RESULT_COLUMNS" "SYS%LPI") '{print $idx}')
   else
     log_output "\nThe system failed to place S2idle entry command, please re-try.\n"
     exit 0


### PR DESCRIPTION
On my laptop, it only show pc3, pc6 and pc10, it could not be parsed correctly.

```
Turbostat output:·
14.951555 sec
CPU%c1→ CPU%c6→ CPU%c7→ Pkg%pc2→Pkg%pc3→Pkg%pc6→Pk%pc10→SYS%LPI
8.76→   42.09→  48.04→  0.17→   0.00→   0.03→   82.80→  0.00
1.93→   0.19→   96.28→  0.17→   0.00→   0.03→   82.82→  0.00
2.85→   0.78→   95.01
1.89→   0.65→   95.97
1.93→   0.30→   97.07
14.62→  83.70→  0.00
15.67→  83.80→  0.00
15.65→  83.77→  0.00
15.50→  83.51→  0.00

CPU Core C7 residency after S2idle is: 48.04 
CPU Package C-state 2 residency after S2idle is: 0.17
CPU Package C-state 3 residency after S2idle is: 0.00
CPU Package C-state 8 residency after S2idle is: 82.80
CPU Package C-state 10 residency after S2idle is: 0.00
S0ix residency after S2idle is:·
(standard_in) 1: syntax error
(standard_in) 1: syntax error
```